### PR TITLE
Fix serial port baud fallback

### DIFF
--- a/nabud/conn.c
+++ b/nabud/conn.c
@@ -227,7 +227,6 @@ conn_add_serial(char *path, unsigned int channel)
 	if (cfsetspeed(&t, NABU_NATIVE_BPS) < 0) {
 		log_error("cfsetspeed(NABU_NATIVE_BPS) on %s failed.",
 		    path);
-		goto bad;
 	}
 
 	if (tcsetattr(fd, TCSANOW, &t) < 0) {


### PR DESCRIPTION
If the serial port does not support NABU_NATIVE_BPS, then the first cfsetspeed call will fail. Thus, by jumping to the bad label on failure, the fallback code never gets executed.

Tested and verified working with a 16550-based RS232 serial port on a modern computer.