### PR TITLE
Set init flag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,5 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    init: true
     ports:
       - 5816:5816


### PR DESCRIPTION
This fixes a problem where SIGINT wasn't being delivered, causing a delay in stopping the container (and also making it impossible to kill it with ctrl-c when run interactively).