### PR TITLE
CygWin compatibility changes

### DIFF
--- a/libfetch/ftp.c
+++ b/libfetch/ftp.c
@@ -56,6 +56,11 @@
  * $ftpioId: ftpio.c,v 1.30 1998/04/11 07:28:53 phk Exp $
  *
  */
+ 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif
 
 #ifdef __linux__
 /* Keep this down to Linux, it can create surprises else where. */
@@ -149,7 +154,9 @@ unmappedaddr(struct sockaddr_in6 *sin6, socklen_t *len)
 	sin4->sin_family = AF_INET;
 	*len = sizeof(struct sockaddr_in);
 #ifdef HAVE_SA_LEN
+#ifndef __CYGWIN__
 	sin4->sin_len = sizeof(struct sockaddr_in);
+#endif	
 #endif
 }
 

--- a/libfetch/http.c
+++ b/libfetch/http.c
@@ -63,6 +63,11 @@
  * SUCH DAMAGE.
  */
 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif
+
 #if defined(__linux__) || defined(__MINT__)
 /* Keep this down to Linux or MiNT, it can create surprises elsewhere. */
 #ifndef _GNU_SOURCE

--- a/libnabud/cli.c
+++ b/libnabud/cli.c
@@ -28,6 +28,11 @@
  * Command line tool helper functions.
  */
 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/libnabud/log.c
+++ b/libnabud/log.c
@@ -28,6 +28,11 @@
  * Logging functions.
  */
 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>

--- a/libnabud/nabuctl_proto.h
+++ b/libnabud/nabuctl_proto.h
@@ -29,7 +29,7 @@
 
 /* Default path to the nabud control channel. */
 #ifdef __CYGWIN__
-#define	NABUCTL_PATH_DEFAULT	".\nabuctl.sock"
+#define	NABUCTL_PATH_DEFAULT	".\\nabuctl.sock"
 #else
 #define	NABUCTL_PATH_DEFAULT	"/tmp/nabuctl.sock"
 #endif

--- a/libnabud/nabuctl_proto.h
+++ b/libnabud/nabuctl_proto.h
@@ -28,7 +28,11 @@
 #define	nabuctl_proto_h_included
 
 /* Default path to the nabud control channel. */
+#ifdef __CYGWIN__
+#define	NABUCTL_PATH_DEFAULT	".\nabuctl.sock"
+#else
 #define	NABUCTL_PATH_DEFAULT	"/tmp/nabuctl.sock"
+#endif
 
 /*
  * Each nabuctl message and each field within each message is prefixed with

--- a/nabud/control.c
+++ b/nabud/control.c
@@ -27,6 +27,11 @@
 /*
  * Support for control messages.
  */
+ 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif 
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/nabud/image.c
+++ b/nabud/image.c
@@ -28,6 +28,11 @@
  * Image management.
  */
 
+// need this for cygwin compiles
+#ifdef __CYGWIN__
+#define _GNU_SOURCE
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif


### PR DESCRIPTION
These changes make version 1.2 compatible with CygWin.  Some of my previous problems were corrected in Version 1.2.  Some others were dumb errors/misunderstanding of mine.